### PR TITLE
Oprava kontroly počtu karet na konci tahu

### DIFF
--- a/pluginy/bang/src/main/java/cz/honza/bang/pluginy/bang/PravidlaBangu.java
+++ b/pluginy/bang/src/main/java/cz/honza/bang/pluginy/bang/PravidlaBangu.java
@@ -241,7 +241,7 @@ public class PravidlaBangu implements HerniPravidla{
 
     @Override
     public boolean hracChceUkoncitTah(Hrac kdo) {
-        if (kdo.getKarty().size() > kdo.getMaximumZivotu() && JE_OMEZENY_POCET_KARET) {
+        if (kdo.getKarty().size() > kdo.getZivoty() && JE_OMEZENY_POCET_KARET) {
             hra.getKomunikator().posliRychleOznameni("Moc karet", kdo);
             return false;
         }


### PR DESCRIPTION
Podle pravidel Bangu musí mít hráč na konci tahu maximálně stejný počet karet jako má aktuálně životů, ne maximum životů postavy. Metoda hracChceUkoncitTah porovnávala počet karet s getMaximumZivotu() místo getZivoty(), takže hráč se sníženým počtem životů mohl v ruce držet víc karet, než by měl.

Nejsem si naprosto jistý, jestli je tohle správná oprava, ale při hře kontrola karet nefungovala správně a našel jsem tuhle nesrovnalost.